### PR TITLE
Add LLMChain endpoints for ticket analysis

### DIFF
--- a/custom-agent-tools-py/main.py
+++ b/custom-agent-tools-py/main.py
@@ -23,6 +23,7 @@ from email.message import EmailMessage
 import requests
 import csv
 from fastapi.responses import StreamingResponse
+import json
 
 app = FastAPI(
     title="SD-MCP Python Agent",
@@ -58,6 +59,27 @@ def store_feedback(query, dense_results, sparse_results, reranked, user_feedback
             cur.execute(
                 "INSERT INTO feedback (feedback_id, log_id, rating, comments, created_at) VALUES (%s, %s, %s, %s, %s)",
                 (str(uuid.uuid4()), query, user_feedback.get("rating", 0), user_feedback.get("comments", ""), datetime.utcnow())
+            )
+            conn.commit()
+
+# Store outputs from LLM chains for analytics
+def store_chain_output(chain_type: str, input_data: dict, output_text: str):
+    with get_pg_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS llm_chain_runs (
+                    run_id UUID PRIMARY KEY,
+                    chain_type TEXT NOT NULL,
+                    input_data JSONB NOT NULL,
+                    output_text TEXT NOT NULL,
+                    created_at TIMESTAMPTZ DEFAULT NOW()
+                )
+                """
+            )
+            cur.execute(
+                "INSERT INTO llm_chain_runs (run_id, chain_type, input_data, output_text, created_at) VALUES (%s, %s, %s, %s, %s)",
+                (str(uuid.uuid4()), chain_type, json.dumps(input_data), output_text, datetime.utcnow())
             )
             conn.commit()
 
@@ -150,6 +172,73 @@ def feedback_loop_endpoint(query: str, llm_output: str, rating: int, comments: O
     store_feedback(query, [], [], [], user_feedback, llm_output)
     return {"status": "feedback received"}
 
+# --- LLMChain-powered endpoints ---
+
+def _get_ticket_summary(ticket_id: int) -> str:
+    with get_pg_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT ticket_summary FROM external_tickets WHERE ticket_id = %s",
+                (ticket_id,)
+            )
+            row = cur.fetchone()
+            if not row:
+                raise HTTPException(status_code=404, detail="Ticket not found")
+            return row["ticket_summary"]
+
+
+@app.post("/llm/triage_ticket")
+def triage_ticket(ticket_id: int):
+    """Classify ticket priority using an LLM chain"""
+    ticket = _get_ticket_summary(ticket_id)
+    prompt = PromptTemplate.from_template(
+        "You are a helpdesk triage assistant. Given the ticket description below, assign a priority label (low, medium, high).\n{ticket}"
+    )
+    chain = LLMChain(llm=OpenAI(temperature=0.2), prompt=prompt)
+    result = chain.run(ticket=ticket)
+    store_chain_output("triage_ticket", {"ticket_id": ticket_id}, result)
+    return {"ticket_id": ticket_id, "triage": result}
+
+
+@app.post("/llm/root_cause")
+def root_cause(ticket_id: int):
+    """Return a likely root cause for the ticket"""
+    ticket = _get_ticket_summary(ticket_id)
+    prompt = PromptTemplate.from_template(
+        "Analyze the following ticket and provide the most likely root cause in one sentence:\n{ticket}"
+    )
+    chain = LLMChain(llm=OpenAI(temperature=0.2), prompt=prompt)
+    result = chain.run(ticket=ticket)
+    store_chain_output("root_cause", {"ticket_id": ticket_id}, result)
+    return {"ticket_id": ticket_id, "root_cause": result}
+
+
+@app.post("/llm/summarize_ticket")
+def summarize_ticket(ticket_id: int):
+    """Summarize the ticket into a short paragraph"""
+    ticket = _get_ticket_summary(ticket_id)
+    prompt = PromptTemplate.from_template(
+        "Provide a concise summary of the following ticket:\n{ticket}"
+    )
+    chain = LLMChain(llm=OpenAI(temperature=0.2), prompt=prompt)
+    result = chain.run(ticket=ticket)
+    store_chain_output("summarize_ticket", {"ticket_id": ticket_id}, result)
+    return {"ticket_id": ticket_id, "summary": result}
+
+
+@app.post("/llm/followup_actions")
+def followup_actions(ticket_id: int):
+    """Suggest follow-up actions for the ticket"""
+    ticket = _get_ticket_summary(ticket_id)
+    prompt = PromptTemplate.from_template(
+        "Based on this ticket, suggest next best follow-up actions in bullet form:\n{ticket}"
+    )
+    chain = LLMChain(llm=OpenAI(temperature=0.2), prompt=prompt)
+    result = chain.run(ticket=ticket)
+    store_chain_output("followup_actions", {"ticket_id": ticket_id}, result)
+    return {"ticket_id": ticket_id, "actions": result}
+
 # All previous endpoints (chatlog, ticket, feedback, problem-link, analytics, LLM chains, email/alerting, etc.) remain unchanged
 
 # TODO: Add more advanced analytics, BI tool integration, and UI usage examples as needed
+

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -205,6 +205,10 @@ This guide provides an overview and usage examples for the main API endpoints ex
 ```bash
 curl -X POST 'http://localhost:8000/ticket' -d 'id=123&title=Example Ticket'
 curl 'http://localhost:8000/search?query=error'
+curl -X POST 'http://localhost:8000/llm/triage_ticket' -d 'ticket_id=123'
+curl -X POST 'http://localhost:8000/llm/root_cause' -d 'ticket_id=123'
+curl -X POST 'http://localhost:8000/llm/summarize_ticket' -d 'ticket_id=123'
+curl -X POST 'http://localhost:8000/llm/followup_actions' -d 'ticket_id=123'
 ```
 
 ### Python


### PR DESCRIPTION
## Summary
- add LLMChain endpoints for ticket triage, root cause analysis, summarization, and follow-up actions
- store chain outputs in `llm_chain_runs` table
- document curl examples for the new endpoints

## Testing
- `python -m py_compile custom-agent-tools-py/main.py`


------
https://chatgpt.com/codex/tasks/task_e_683f5e3552048333b65746afc99198ea