### PR TITLE
Add metadata endpoint and dynamic filters

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -89,6 +89,14 @@ POST http://localhost:8000/feedback
 }
 ```
 
+### Get Filter Metadata
+The frontend uses the `/metadata` endpoint to populate search filters.
+
+```bash
+curl http://localhost:8000/metadata
+```
+This returns JSON lists of available categories, ticket fields, and document types.
+
 ---
 
 ## 7. Authentication/Authorization


### PR DESCRIPTION
## Summary
- expose `/metadata` endpoint in FastAPI backend
- load metadata in React frontend and render filter checkboxes
- include filter metadata endpoint in the user guide

## Testing
- `python -m py_compile RAG_Scripts/main.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5e3c58048333ace1a644dd1caed3