### PR TITLE
Add FastMCP manifest support

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ pip install -r requirements.txt  # or see README for manual install
 uvicorn main:app --reload
 ```
 
+After the server starts, its manifest can be retrieved from
+`http://localhost:8000/.well-known/ai-plugin.json` for FastMCP discovery.
+
 ### Integration
 
 Once running, the MCP server exposes tools and resources accessible via the Model Context Protocol, allowing the AI Agent to offload these responsibilities.

--- a/custom-agent-tools-py/README.md
+++ b/custom-agent-tools-py/README.md
@@ -45,6 +45,9 @@ pip install langchain langchain-community fastapi uvicorn pydantic psycopg2-bina
 uvicorn main:app --reload
 ```
 
+After starting the server, the tool manifest is available at
+`http://localhost:8000/.well-known/ai-plugin.json`.
+
 ## Email/Alerting Configuration
 
 Set the following environment variables for email and Slack integration:


### PR DESCRIPTION
## Summary
- create an optional FastMCP server instance
- expose ai-plugin manifest route
- mark search, feedback and notification routes with `@tool`
- mention discovery endpoint in documentation

## Testing
- `python -m py_compile custom-agent-tools-py/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68414e83bbec8333baa95ab94346a3e2