### PR TITLE
Improve API docs and OpenAPI schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ UI components: chat, ticket management, analytics dashboards, feedback forms, re
 ### 5. Usage Examples
 
 - Example API calls (curl, Python, Postman) are provided in the documentation and `/usage/example` endpoint of the MCP server.
+- The generated OpenAPI schemas are available under `docs/` for easy client generation.
 - Sample workflows: creating a ticket, searching knowledge, submitting feedback, analytics export.
 
 ### 6. Authentication/Authorization

--- a/custom-agent-tools-py/main.py
+++ b/custom-agent-tools-py/main.py
@@ -6,7 +6,7 @@ Adds hybrid reranking, context window optimization, dynamic prompt engineering, 
 """
 
 from fastapi import FastAPI, HTTPException, Depends, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Optional
 import uuid
 from datetime import datetime
@@ -171,6 +171,17 @@ def search(
     max_tokens: int = 2048,
     user: Optional[str] = None
 ):
+    """Run a hybrid RAG search and return the generated answer.
+
+    **Parameters**
+    - `query`: user search text
+    - `limit`: number of documents to retrieve
+    - `rerank`: whether to apply hybrid reranking
+    - `max_tokens`: maximum context window
+    - `user`: optional user identifier
+
+    **Returns** the answer string with the context chunks used.
+    """
     dense_docs = dense_retriever.get_relevant_documents(query)
     with get_pg_conn() as conn:
         with conn.cursor() as cur:
@@ -201,6 +212,7 @@ def search(
 # Feedback loop endpoint
 @app.post("/feedback-loop")
 def feedback_loop_endpoint(query: str, llm_output: str, rating: int, comments: Optional[str] = None):
+    """Record user feedback for an LLM answer."""
     user_feedback = {"rating": rating, "comments": comments or ""}
     feedback_loop(llm_output, user_feedback)
     store_feedback(query, [], [], [], user_feedback, llm_output)
@@ -395,22 +407,28 @@ def followup_actions(ticket_id: int):
 
 
 class TeamsPayload(BaseModel):
-    message: str
+    message: str = Field(..., description="Notification text", example="Server CPU high")
 
 
 @app.post("/notify/teams")
 def notify_teams(payload: TeamsPayload):
+    """Send a Microsoft Teams message."""
     return post_to_teams(payload.message)
 
 
 class PagerDutyPayload(BaseModel):
-    summary: str
-    severity: Optional[str] = "info"
-    source: Optional[str] = "custom-agent-tools-py"
+    summary: str = Field(..., description="Incident summary", example="DB down")
+    severity: Optional[str] = Field(
+        "info", description="PagerDuty severity level", example="critical"
+    )
+    source: Optional[str] = Field(
+        "custom-agent-tools-py", description="Event source", example="sd-agent"
+    )
 
 
 @app.post("/notify/pagerduty")
 def notify_pagerduty(payload: PagerDutyPayload):
+    """Trigger a PagerDuty incident."""
     return trigger_pagerduty(payload.summary, payload.severity, payload.source)
 
 

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -245,7 +245,7 @@ print(response.json())
 
 ### Postman
 
-- Import the OpenAPI schema from the FastAPI backend to generate all endpoints.
+- Import the OpenAPI schema from the FastAPI backend to generate all endpoints. The schemas now include concise descriptions and example values.
 - Example: POST to `/feedback` with JSON body.
 
 ---

--- a/docs/openapi_mcp.json
+++ b/docs/openapi_mcp.json
@@ -1,0 +1,707 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "SD-MCP Python Agent",
+    "description": "Python/Langchain MCP server for Service Desk Agent with advanced RAG, LLM, analytics, UI, and feedback loops",
+    "version": "0.9"
+  },
+  "paths": {
+    "/search": {
+      "get": {
+        "summary": "Search",
+        "description": "Run a hybrid RAG search and return the generated answer.\n\n**Parameters**\n- `query`: user search text\n- `limit`: number of documents to retrieve\n- `rerank`: whether to apply hybrid reranking\n- `max_tokens`: maximum context window\n- `user`: optional user identifier\n\n**Returns** the answer string with the context chunks used.",
+        "operationId": "search_search_get",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Query"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 5,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "rerank",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Rerank"
+            }
+          },
+          {
+            "name": "max_tokens",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 2048,
+              "title": "Max Tokens"
+            }
+          },
+          {
+            "name": "user",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/feedback-loop": {
+      "post": {
+        "summary": "Feedback Loop Endpoint",
+        "description": "Record user feedback for an LLM answer.",
+        "operationId": "feedback_loop_endpoint_feedback_loop_post",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Query"
+            }
+          },
+          {
+            "name": "llm_output",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Llm Output"
+            }
+          },
+          {
+            "name": "rating",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Rating"
+            }
+          },
+          {
+            "name": "comments",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Comments"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/analytics/ticket-volume": {
+      "get": {
+        "summary": "Ticket Volume",
+        "description": "Return ticket counts per day between start and end dates.",
+        "operationId": "ticket_volume_analytics_ticket_volume_get",
+        "parameters": [
+          {
+            "name": "start",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Start"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "End"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/analytics/resolution-times": {
+      "get": {
+        "summary": "Resolution Times",
+        "description": "Return average ticket resolution time in hours.",
+        "operationId": "resolution_times_analytics_resolution_times_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/analytics/sla-compliance": {
+      "get": {
+        "summary": "Sla Compliance",
+        "description": "Return percentage of tickets resolved within the given SLA hours.",
+        "operationId": "sla_compliance_analytics_sla_compliance_get",
+        "parameters": [
+          {
+            "name": "hours",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 48,
+              "title": "Hours"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/analytics/agent-leaderboard": {
+      "get": {
+        "summary": "Agent Leaderboard",
+        "description": "Return top agents by metric value from agent_metrics.",
+        "operationId": "agent_leaderboard_analytics_agent_leaderboard_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 10,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/analytics/document-usage": {
+      "get": {
+        "summary": "Document Usage",
+        "description": "Return document retrieval counts from retrieval history.",
+        "operationId": "document_usage_analytics_document_usage_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/analytics/export": {
+      "get": {
+        "summary": "Export Analytics",
+        "description": "Export analytics data as JSON or CSV.",
+        "operationId": "export_analytics_analytics_export_get",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Type"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "json",
+              "title": "Format"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/llm/triage_ticket": {
+      "post": {
+        "summary": "Triage Ticket",
+        "description": "Classify ticket priority using an LLM chain",
+        "operationId": "triage_ticket_llm_triage_ticket_post",
+        "parameters": [
+          {
+            "name": "ticket_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Ticket Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/llm/root_cause": {
+      "post": {
+        "summary": "Root Cause",
+        "description": "Return a likely root cause for the ticket",
+        "operationId": "root_cause_llm_root_cause_post",
+        "parameters": [
+          {
+            "name": "ticket_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Ticket Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/llm/summarize_ticket": {
+      "post": {
+        "summary": "Summarize Ticket",
+        "description": "Summarize the ticket into a short paragraph",
+        "operationId": "summarize_ticket_llm_summarize_ticket_post",
+        "parameters": [
+          {
+            "name": "ticket_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Ticket Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/llm/followup_actions": {
+      "post": {
+        "summary": "Followup Actions",
+        "description": "Suggest follow-up actions for the ticket",
+        "operationId": "followup_actions_llm_followup_actions_post",
+        "parameters": [
+          {
+            "name": "ticket_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Ticket Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notify/teams": {
+      "post": {
+        "summary": "Notify Teams",
+        "description": "Send a Microsoft Teams message.",
+        "operationId": "notify_teams_notify_teams_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TeamsPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notify/pagerduty": {
+      "post": {
+        "summary": "Notify Pagerduty",
+        "description": "Trigger a PagerDuty incident.",
+        "operationId": "notify_pagerduty_notify_pagerduty_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PagerDutyPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "PagerDutyPayload": {
+        "properties": {
+          "summary": {
+            "type": "string",
+            "title": "Summary",
+            "description": "Incident summary",
+            "example": "DB down"
+          },
+          "severity": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Severity",
+            "description": "PagerDuty severity level",
+            "default": "info",
+            "example": "critical"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source",
+            "description": "Event source",
+            "default": "custom-agent-tools-py",
+            "example": "sd-agent"
+          }
+        },
+        "type": "object",
+        "required": [
+          "summary"
+        ],
+        "title": "PagerDutyPayload"
+      },
+      "TeamsPayload": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "Notification text",
+            "example": "Server CPU high"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message"
+        ],
+        "title": "TeamsPayload"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add example values to Pydantic models
- document FastAPI endpoints with concise docstrings
- expose sample OpenAPI schema
- mention OpenAPI files in the docs

## Testing
- `python -m py_compile RAG_Scripts/main.py custom-agent-tools-py/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68414e8692908333a3ab818309d69eb5